### PR TITLE
Refactor ingest router status tracking

### DIFF
--- a/backend/app/routers/ingest.py
+++ b/backend/app/routers/ingest.py
@@ -2,12 +2,9 @@
 from __future__ import annotations
 
 import os
-import random
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Dict, List
-from uuid import uuid4
+from typing import Any, Dict, Optional
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
 
@@ -18,103 +15,161 @@ ORIGINAL_DIR.mkdir(parents=True, exist_ok=True)
 
 HEALTH_UPLOAD_ID = "healthcheck"
 
+STAGE_NORMALIZATION = {
+    "ready": "ready",
+    "validate": "validate",
+    "validation": "validate",
+    "validating": "validate",
+    "queued": "validate",
+    "proxy": "make_proxy",
+    "make_proxy": "make_proxy",
+    "mezzanine": "transcode_mezz",
+    "transcode": "transcode_mezz",
+    "transcode_mezz": "transcode_mezz",
+    "thumbs": "thumbs",
+    "thumbnails": "thumbs",
+    "thumbnail": "thumbs",
+    "error": "error",
+}
 
-@dataclass
-class StageTiming:
-    """Represents a phase within the ingest simulation."""
-
-    name: str
-    start: datetime
-    end: datetime
-
-
-@dataclass
-class UploadJob:
-    """In-memory representation of an upload job."""
-
-    upload_id: str
-    extension: str
-    started_at: datetime
-    stages: List[StageTiming]
-
-    @property
-    def total_duration(self) -> float:
-        """Return the total duration of the simulated pipeline."""
-
-        active_stages = [stage for stage in self.stages if stage.end > stage.start]
-        if not active_stages:
-            return 0.0
-        return (active_stages[-1].end - active_stages[0].start).total_seconds()
-
-
-_upload_store: Dict[str, UploadJob] = {}
+DEFAULT_STAGE = "ready"
 
 router = APIRouter(prefix="/ingest", tags=["ingest"])
 
-
-def _schedule_job(upload_id: str, extension: str) -> UploadJob:
-    """Create timing metadata for a new ingest job."""
-
-    started_at = datetime.now(timezone.utc)
-    total_duration = random.uniform(3.0, 5.0)
-    validate_duration = max(1.0, total_duration * 0.35)
-    proxy_duration = max(1.0, total_duration - validate_duration)
-
-    validate_end = started_at + timedelta(seconds=validate_duration)
-    proxy_end = validate_end + timedelta(seconds=proxy_duration)
-
-    stages = [
-        StageTiming(name="validate", start=started_at, end=validate_end),
-        StageTiming(name="proxy", start=validate_end, end=proxy_end),
-        StageTiming(name="ready", start=proxy_end, end=proxy_end),
-    ]
-
-    job = UploadJob(
-        upload_id=upload_id,
-        extension=extension,
-        started_at=started_at,
-        stages=stages,
-    )
-    _upload_store[upload_id] = job
-    return job
+_upload_store: Dict[str, Dict[str, Any]] = {}
 
 
-def _ensure_health_job() -> None:
-    """Seed a ready job used for health checks."""
+def _empty_assets() -> Dict[str, Optional[str]]:
+    """Return empty asset placeholders for a status payload."""
 
-    if HEALTH_UPLOAD_ID in _upload_store:
-        return
-
-    ready_time = datetime.now(timezone.utc) - timedelta(seconds=5)
-    stages = [
-        StageTiming(name="ready", start=ready_time, end=ready_time),
-    ]
-    _upload_store[HEALTH_UPLOAD_ID] = UploadJob(
-        upload_id=HEALTH_UPLOAD_ID,
-        extension="",
-        started_at=ready_time,
-        stages=stages,
-    )
+    return {"original_url": None, "proxy_url": None, "mezzanine_url": None}
 
 
-def _compute_status(job: UploadJob) -> Dict[str, object]:
-    """Return the computed status payload for a job."""
+def _normalize_stage(stage: Optional[str]) -> str:
+    """Normalize a stage name to the supported vocabulary."""
 
-    now = datetime.now(timezone.utc)
+    if not stage:
+        return DEFAULT_STAGE
+    normalized = STAGE_NORMALIZATION.get(stage.lower())
+    return normalized or ("error" if stage else DEFAULT_STAGE)
 
-    if job.total_duration <= 0 or now >= job.stages[-1].end:
-        return {"status": "ready", "stage": "ready", "progress": 100}
 
-    total_duration = job.total_duration
-    elapsed = max(0.0, (now - job.started_at).total_seconds())
-    progress = min(99, int(round((elapsed / total_duration) * 100)))
+def _clamp_progress(value: int) -> int:
+    """Clamp progress values to a sane 0-100 range."""
 
-    for stage in job.stages:
-        if stage.name == "ready":
-            break
-        if now < stage.end:
-            return {"status": "processing", "stage": stage.name, "progress": progress}
-    return {"status": "ready", "stage": "ready", "progress": 100}
+    return max(0, min(100, int(value)))
+
+
+def _build_status_payload(
+    status: str,
+    stage: str,
+    progress: int,
+    assets: Dict[str, Optional[str]],
+    message: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Construct a normalized status payload."""
+
+    normalized_assets = {
+        "original_url": assets.get("original_url"),
+        "proxy_url": assets.get("proxy_url"),
+        "mezzanine_url": assets.get("mezzanine_url"),
+    }
+    payload: Dict[str, Any] = {
+        "status": status,
+        "stage": _normalize_stage(stage),
+        "progress": _clamp_progress(progress),
+        "assets": normalized_assets,
+    }
+    if message:
+        payload["message"] = message
+    return payload
+
+
+def _clone_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a shallow copy suitable for responses or storage."""
+
+    cloned = {
+        "status": payload["status"],
+        "stage": payload["stage"],
+        "progress": payload["progress"],
+        "assets": {
+            "original_url": payload["assets"].get("original_url"),
+            "proxy_url": payload["assets"].get("proxy_url"),
+            "mezzanine_url": payload["assets"].get("mezzanine_url"),
+        },
+    }
+    if "message" in payload:
+        cloned["message"] = payload["message"]
+    return cloned
+
+
+def _store_status(
+    upload_id: str,
+    status: str,
+    stage: str,
+    progress: int,
+    assets: Dict[str, Optional[str]],
+    message: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Persist a status payload in memory and return a response copy."""
+
+    payload = _build_status_payload(status, stage, progress, assets, message)
+    _upload_store[upload_id] = _clone_payload(payload)
+    return _clone_payload(payload)
+
+
+def _asset_urls(upload_id: str, extension: Optional[str]) -> Dict[str, Optional[str]]:
+    """Generate asset URLs for a stored upload."""
+
+    if not extension:
+        return _empty_assets()
+    suffix = extension if extension.startswith(".") else f".{extension}"
+    asset_path = f"/assets/original/{upload_id}{suffix}"
+    return {"original_url": asset_path, "proxy_url": asset_path, "mezzanine_url": None}
+
+
+def _locate_existing_extension(upload_id: str) -> Optional[str]:
+    """Look for an on-disk upload and return its extension if present."""
+
+    for extension in sorted(ALLOWED_EXTENSIONS):
+        candidate = ORIGINAL_DIR / f"{upload_id}{extension}"
+        if candidate.exists():
+            return extension
+    return None
+
+
+def _is_uuid_like(value: str) -> bool:
+    """Determine if a value resembles a UUID string."""
+
+    try:
+        UUID(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _ensure_health_seed() -> None:
+    """Ensure a healthcheck job exists in the in-memory store."""
+
+    if HEALTH_UPLOAD_ID not in _upload_store:
+        _store_status(HEALTH_UPLOAD_ID, "ready", "ready", 100, _empty_assets())
+
+
+def _resolve_status(upload_id: str) -> Dict[str, Any]:
+    """Resolve status information for a given upload identifier."""
+
+    if upload_id in _upload_store:
+        return _clone_payload(_upload_store[upload_id])
+
+    extension = _locate_existing_extension(upload_id)
+    if extension:
+        return _store_status(upload_id, "ready", "ready", 100, _asset_urls(upload_id, extension))
+
+    if upload_id == HEALTH_UPLOAD_ID or _is_uuid_like(upload_id):
+        return _build_status_payload("queued", "validate", 0, _empty_assets())
+
+    message = f"Unknown upload_id '{upload_id}'"
+    return _build_status_payload("error", "error", 0, _empty_assets(), message=message)
 
 
 async def _write_file(destination: Path, upload: UploadFile) -> None:
@@ -153,25 +208,35 @@ async def upload_video(file: UploadFile = File(...)) -> Dict[str, object]:
     except OSError as exc:  # pragma: no cover - guard for filesystem errors
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Unable to save upload") from exc
 
-    _schedule_job(upload_id, extension)
+    assets = _asset_urls(upload_id, extension)
+    _store_status(upload_id, "ready", "ready", 100, assets)
 
-    asset_path = f"/assets/original/{upload_id}{extension}"
     return {
         "upload_id": upload_id,
-        "original_url": asset_path,
-        "proxy_url": asset_path,
-        "mezzanine_url": None,
+        "original_url": assets["original_url"],
+        "proxy_url": assets["proxy_url"],
+        "mezzanine_url": assets["mezzanine_url"],
     }
 
 
 @router.get("/status")
-def get_status(upload_id: str = Query(..., description="Upload identifier")) -> Dict[str, object]:
-    """Return the simulated status for an upload job."""
+def get_status(upload_id: str = Query(..., description="Upload identifier")) -> Dict[str, Any]:
+    """Return the status for an upload job."""
 
-    _ensure_health_job()
+    _ensure_health_seed()
+    return _resolve_status(upload_id)
 
-    job = _upload_store.get(upload_id)
-    if not job:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Upload not found")
 
-    return _compute_status(job)
+@router.get("/health")
+def get_health(upload_id: Optional[str] = Query(None, description="Optional upload identifier")) -> Dict[str, Any]:
+    """Report ingest module readiness."""
+
+    _ensure_health_seed()
+
+    if upload_id:
+        status_payload = _resolve_status(upload_id)
+        ok = status_payload["status"] != "error"
+    else:
+        ok = any(payload["status"] != "error" for payload in _upload_store.values())
+
+    return {"ok": bool(ok), "module": "ingest"}


### PR DESCRIPTION
## Summary
- replace the ingest job timing simulation with an in-memory status store that tracks stage, progress, messages, and asset URLs
- return full status payloads with normalized stages and graceful fallbacks for unknown upload IDs
- add an ingest health endpoint that reports readiness based on the in-memory status store

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68d1e0f834bc8325bf64af564fe2fef5