### PR TITLE
Improve ingest health polling resilience

### DIFF
--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -13,7 +13,12 @@ const eventsPayload = {
 };
 
 const formationPayload = { formation: { front_row: ['p1'], back_row: ['p2'] } };
-const modulesPayload = { modules: [{ name: 'analysis', status: 'healthy', enabled: true }] };
+const modulesPayload = {
+  modules: [
+    { name: 'analysis', status: 'healthy', enabled: true },
+    { name: 'ingest', status: 'healthy', enabled: true },
+  ],
+};
 
 type FetchArgs = [input: RequestInfo | URL, init?: RequestInit];
 
@@ -30,6 +35,15 @@ beforeEach(() => {
     if (url.endsWith('/modules/health')) {
       return new Response(JSON.stringify(modulesPayload), { status: 200 });
     }
+    if (url.endsWith('/ingest/health')) {
+      return new Response(JSON.stringify({ ok: true, module: 'ingest' }), { status: 200 });
+    }
+    if (url.includes('/ingest/status')) {
+      return new Response(
+        JSON.stringify({ status: 'ready', stage: 'ready', progress: 100 }),
+        { status: 200 },
+      );
+    }
     return new Response('{}', { status: 200 });
   });
 });
@@ -41,5 +55,6 @@ afterEach(() => {
 test('renders VolleySense layout snapshot', async () => {
   const { asFragment } = render(<App />);
   await screen.findByText('VolleySense Console');
+  await screen.findByText('Ingest: ready');
   expect(asFragment()).toMatchSnapshot();
 });

--- a/web/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/web/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`renders VolleySense layout snapshot 1`] = `
               d="m22 12.65-9.17 4.16a2 2 0 0 1-1.66 0L2 12.65"
             />
           </svg>
-           Modules online: 1
+           Modules online: 2
           <button
             class="rounded-full border px-3 py-1 text-xs font-medium transition focus:outline-none focus:ring-2 focus:ring-brand border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
             type="button"
@@ -208,6 +208,39 @@ exports[`renders VolleySense layout snapshot 1`] = `
                 class="text-sm font-medium capitalize"
               >
                 analysis
+              </span>
+              <span
+                class="flex items-center gap-1 text-xs"
+              >
+                <svg
+                  class="lucide lucide-check-circle h-4 w-4 text-emerald-400"
+                  fill="none"
+                  height="24"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M22 11.08V12a10 10 0 1 1-5.93-9.14"
+                  />
+                  <path
+                    d="m9 11 3 3L22 4"
+                  />
+                </svg>
+                healthy
+              </span>
+            </li>
+            <li
+              class="flex items-center justify-between rounded-md bg-slate-900 border border-slate-800 px-3 py-2"
+            >
+              <span
+                class="text-sm font-medium capitalize"
+              >
+                ingest
               </span>
               <span
                 class="flex items-center gap-1 text-xs"

--- a/web/src/hooks/useModuleHealth.ts
+++ b/web/src/hooks/useModuleHealth.ts
@@ -1,6 +1,26 @@
 import { useEffect, useState } from 'react';
 import { ModuleHealth } from '../data/types';
 
+const markIngestStatus = (modules: ModuleHealth[], status: string): ModuleHealth[] => {
+  let ingestFound = false;
+  const nextModules = modules.map((module) => {
+    if (module.name !== 'ingest') {
+      return module;
+    }
+    ingestFound = true;
+    return {
+      ...module,
+      status,
+    };
+  });
+
+  if (!ingestFound) {
+    nextModules.push({ name: 'ingest', status, enabled: true });
+  }
+
+  return nextModules;
+};
+
 export const useModuleHealth = () => {
   const [modules, setModules] = useState<ModuleHealth[]>([]);
 
@@ -15,16 +35,38 @@ export const useModuleHealth = () => {
         }
         const payload = await response.json();
         if (cancelled) return;
-        setModules(payload.modules);
+
+        let nextModules: ModuleHealth[] = payload.modules;
+
+        try {
+          const ingestResponse = await fetch('/ingest/health');
+          if (!ingestResponse.ok) {
+            throw new Error('Unable to load ingest health');
+          }
+          const ingestPayload = await ingestResponse.json();
+          if (!ingestPayload.ok) {
+            nextModules = markIngestStatus(nextModules, 'degraded');
+          }
+        } catch (error) {
+          nextModules = markIngestStatus(nextModules, 'degraded');
+        }
+
+        if (cancelled) return;
+        setModules(nextModules);
       } catch (error) {
         if (cancelled) return;
-        setModules([
-          {
-            name: 'core',
-            status: (error as Error).message,
-            enabled: true,
-          },
-        ]);
+        setModules((current) => {
+          if (current.length > 0) {
+            return current;
+          }
+          return [
+            {
+              name: 'core',
+              status: (error as Error).message,
+              enabled: true,
+            },
+          ];
+        });
       }
     };
 


### PR DESCRIPTION
## Summary
- merge ingest health polling into the module health hook so ingest degrades on failures without touching other modules
- refactor the app header to poll ingest health, fall back gracefully when ingest is disabled, and only query status for progress updates
- update the app test fixtures and snapshot to cover the new ingest endpoints

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d1e8dd46688325a0eb6a1f375bcb03