### PR TITLE
Handle ingest status assets and messaging

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,7 +13,7 @@ import { ModuleHealthList } from './components/ModuleHealthList';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { UploadDialog } from './components/UploadDialog';
 import { VideoViewport, VideoViewportHandle } from './components/VideoViewport';
-import { LogFilters, UploadResponse, UploadStatus } from './data/types';
+import { LogFilters, UploadResponse, UploadStatus, UPLOAD_STAGE_LABELS } from './data/types';
 import LogsTab from './pages/LogsTab';
 
 const AppShell: React.FC = () => {
@@ -36,9 +36,21 @@ const AppShell: React.FC = () => {
   const [logFilters, setLogFilters] = useState<LogFilters>({});
 
   const apiBase = useMemo(() => import.meta.env.VITE_API_URL ?? 'http://localhost:8000', []);
+  const formatStageLabel = useCallback((stage?: string | null) => {
+    if (!stage) {
+      return 'Ready';
+    }
+    const label = UPLOAD_STAGE_LABELS[stage];
+    if (label) {
+      return label;
+    }
+    const fallback = stage.replace(/_/g, ' ');
+    return fallback.charAt(0).toUpperCase() + fallback.slice(1);
+  }, []);
+
   const healthLabel = useMemo(() => {
     if (ingestHealth === 'online') {
-      return `Ingest: ${ingestStage || 'ready'}`;
+      return `Ingest: ${formatStageLabel(ingestStage)}`;
     }
     if (ingestHealth === 'degraded') {
       return 'Ingest: degraded';
@@ -47,7 +59,7 @@ const AppShell: React.FC = () => {
       return 'Ingest: disabled';
     }
     return 'Ingest: checking…';
-  }, [ingestHealth, ingestStage]);
+  }, [formatStageLabel, ingestHealth, ingestStage]);
 
   const healthTone = useMemo(() => {
     switch (ingestHealth) {

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -55,6 +55,6 @@ afterEach(() => {
 test('renders VolleySense layout snapshot', async () => {
   const { asFragment } = render(<App />);
   await screen.findByText('VolleySense Console');
-  await screen.findByText('Ingest: ready');
+  await screen.findByText('Ingest: Ready');
   expect(asFragment()).toMatchSnapshot();
 });

--- a/web/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/web/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`renders VolleySense layout snapshot 1`] = `
             class="rounded-full border px-3 py-1 text-xs font-medium transition focus:outline-none focus:ring-2 focus:ring-brand border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
             type="button"
           >
-            Ingest: ready
+            Ingest: Ready
           </button>
           <button
             class="rounded-md bg-brand px-3 py-2 text-sm font-semibold text-white"

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -31,11 +31,29 @@ export interface UploadResponse {
   mezzanine_url: string | null;
 }
 
+export interface UploadStatusAssets {
+  original_url: string;
+  proxy_url: string;
+  mezzanine_url: string | null;
+}
+
 export interface UploadStatus {
   status: string;
   stage: string;
   progress: number;
+  message?: string;
+  assets?: UploadStatusAssets;
 }
+
+export const UPLOAD_STAGE_LABELS: Record<string, string> = {
+  validate: 'Validating source',
+  transcode_mezz: 'Transcoding mezzanine',
+  make_proxy: 'Preparing proxy',
+  thumbs: 'Generating thumbnails',
+  ready: 'Ready',
+  error: 'Error',
+  proxy: 'Preparing proxy',
+};
 
 export interface LogEntry {
   ts: string | number;


### PR DESCRIPTION
## Summary
- extend the ingest status shape with optional messaging, asset metadata, and shared stage labels
- surface the expanded ingest stages and messages in the upload dialog while using returned asset URLs for playback
- humanize ingest stage labels across the app and refresh associated tests

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1edf0d5888325ac5ce08a0c318b40