### PR TITLE
Ensure new ingest routes take precedence

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -70,8 +70,8 @@ if settings.feature_flags.get("trainer", True):
 if settings.feature_flags.get("insights", True):
     app.include_router(insights.router)
 if settings.feature_flags.get("ingest", True):
-    app.include_router(legacy_ingest.router)
     app.include_router(ingest_router.router)
+    app.include_router(legacy_ingest.router)
 if settings.feature_flags.get("screen_snap", True):
     app.include_router(screensnap.router)
 

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -1,0 +1,54 @@
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.routers import ingest as upload_ingest
+from app.services import ingest as legacy_ingest_service
+
+
+@pytest.fixture(autouse=True)
+def reset_ingest_state():
+    """Ensure ingest state stores do not leak between tests."""
+
+    upload_ingest._upload_store.clear()
+    legacy_ingest_service.job_store._jobs.clear()
+    yield
+    upload_ingest._upload_store.clear()
+    legacy_ingest_service.job_store._jobs.clear()
+
+
+def test_ingest_status_endpoint_returns_payload():
+    client = TestClient(app)
+    upload_id = str(uuid4())
+
+    response = client.get("/ingest/status", params={"upload_id": upload_id})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"]
+    assert set(payload["assets"].keys()) == {"original_url", "proxy_url", "mezzanine_url"}
+
+
+def test_ingest_health_endpoint_reports_ok():
+    client = TestClient(app)
+
+    response = client.get("/ingest/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {"ok": True, "module": "ingest"}
+
+
+def test_legacy_ingest_job_endpoints_remain_accessible():
+    client = TestClient(app)
+
+    creation = client.post("/ingest", json={"source_url": "http://example.com/video.mp4"})
+    assert creation.status_code == 200
+    job_id = creation.json()["job_id"]
+
+    status_response = client.get(f"/ingest/{job_id}", params={"advance": False})
+
+    assert status_response.status_code == 200
+    assert status_response.json()["job_id"] == job_id


### PR DESCRIPTION
## Summary
- Include the new ingest router ahead of the legacy router so static endpoints such as `/ingest/status` and `/ingest/health` are not shadowed by dynamic job routes.
- Add FastAPI client tests covering the new ingest status and health endpoints as well as the legacy job endpoints.

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68d203bc9aac83258d1664a185b7ee58