### PR TITLE
Namespace legacy ingest routes

### DIFF
--- a/backend/app/api/ingest.py
+++ b/backend/app/api/ingest.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from ..services.ingest import job_store
 
-router = APIRouter()
+router = APIRouter(prefix="/legacy-ingest")
 
 PROGRESS_MAP = {
     "queued": 0.05,
@@ -21,7 +21,7 @@ class IngestRequest(BaseModel):
     source_url: str
 
 
-@router.post("/ingest")
+@router.post("")
 def start_ingest(payload: IngestRequest) -> dict:
     job = job_store.create_job(payload.source_url)
     state = job["state"]
@@ -33,7 +33,7 @@ def start_ingest(payload: IngestRequest) -> dict:
     }
 
 
-@router.get("/ingest/{job_id}")
+@router.get("/{job_id}")
 def get_ingest_status(job_id: str, advance: bool = Query(True)) -> dict:
     try:
         job = job_store.advance_job(job_id) if advance else job_store.peek_job(job_id)

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -44,11 +44,15 @@ def test_ingest_health_endpoint_reports_ok():
 def test_legacy_ingest_job_endpoints_remain_accessible():
     client = TestClient(app)
 
-    creation = client.post("/ingest", json={"source_url": "http://example.com/video.mp4"})
+    creation = client.post(
+        "/legacy-ingest", json={"source_url": "http://example.com/video.mp4"}
+    )
     assert creation.status_code == 200
     job_id = creation.json()["job_id"]
 
-    status_response = client.get(f"/ingest/{job_id}", params={"advance": False})
+    status_response = client.get(
+        f"/legacy-ingest/{job_id}", params={"advance": False}
+    )
 
     assert status_response.status_code == 200
     assert status_response.json()["job_id"] == job_id


### PR DESCRIPTION
## Summary
- scope the legacy ingest API under a dedicated /legacy-ingest prefix to avoid path collisions
- update backend ingest tests to reference the new legacy endpoints

## Testing
- pytest backend/tests/test_ingest.py

------
https://chatgpt.com/codex/tasks/task_e_68d20e53e5308325937b01760389e48c