### PR TITLE
Add ingest worker pipeline with staged progress

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,8 +15,7 @@ from starlette.responses import Response
 
 from .api import analyze, events, exports, ingest as legacy_ingest, insights, modules, screensnap, stats, trainer
 from .config import get_settings
-from .routers import ingest as ingest_router
-from .routers import logs
+from .routers import ingest, logs
 from .services.logbuffer import LogBuffer
 from .services.loghandler import LogBufferHandler
 
@@ -62,6 +61,7 @@ app.include_router(events.router)
 app.include_router(stats.router)
 app.include_router(analyze.router)
 app.include_router(logs.router)
+app.include_router(ingest.router)
 
 if settings.feature_flags.get("exports", True):
     app.include_router(exports.router)
@@ -70,7 +70,6 @@ if settings.feature_flags.get("trainer", True):
 if settings.feature_flags.get("insights", True):
     app.include_router(insights.router)
 if settings.feature_flags.get("ingest", True):
-    app.include_router(ingest_router.router)
     app.include_router(legacy_ingest.router)
 if settings.feature_flags.get("screen_snap", True):
     app.include_router(screensnap.router)

--- a/backend/app/services/ingest_state.py
+++ b/backend/app/services/ingest_state.py
@@ -1,0 +1,103 @@
+"""Simple in-memory ingest job state management."""
+from __future__ import annotations
+
+from copy import deepcopy
+from threading import Lock
+from typing import Any, Dict, Optional
+
+
+Job = Dict[str, Any]
+
+_jobs: Dict[str, Job] = {}
+_job_meta: Dict[str, Dict[str, Any]] = {}
+_lock = Lock()
+
+
+def _default_assets(original_url: str) -> Dict[str, Optional[str]]:
+    return {
+        "original_url": original_url,
+        "mezzanine_url": None,
+        "proxy_url": None,
+        "thumbs_glob": None,
+        "keyframes_csv": None,
+    }
+
+
+def _clone(job: Job) -> Job:
+    cloned = deepcopy(job)
+    if cloned.get("message") is None:
+        cloned.pop("message", None)
+    return cloned
+
+
+def create_job(upload_id: str, original_path: str, original_url: str) -> Job:
+    """Register a new ingest job in memory."""
+
+    with _lock:
+        job: Job = {
+            "status": "queued",
+            "stage": "queued",
+            "progress": 0,
+            "assets": _default_assets(original_url),
+        }
+        _jobs[upload_id] = job
+        _job_meta[upload_id] = {
+            "original_path": original_path,
+            "original_url": original_url,
+        }
+        return _clone(job)
+
+
+def update_job(upload_id: str, **fields: Any) -> Job:
+    """Update a stored job and return the updated snapshot."""
+
+    with _lock:
+        if upload_id not in _jobs:
+            raise KeyError(upload_id)
+
+        job = _jobs[upload_id]
+
+        assets_update: Optional[Dict[str, Optional[str]]] = fields.pop("assets", None)
+
+        if "message" in fields:
+            message = fields.pop("message")
+            if message is None:
+                job.pop("message", None)
+            else:
+                job["message"] = message
+
+        for key, value in fields.items():
+            job[key] = value
+
+        if assets_update is not None:
+            assets = job.setdefault("assets", {})
+            for key, value in assets_update.items():
+                assets[key] = value
+
+        return _clone(job)
+
+
+def get_job(upload_id: str) -> Optional[Job]:
+    """Return a copy of a stored job, if it exists."""
+
+    with _lock:
+        job = _jobs.get(upload_id)
+        if not job:
+            return None
+        return _clone(job)
+
+
+def get_job_meta(upload_id: str) -> Optional[Dict[str, Any]]:
+    with _lock:
+        meta = _job_meta.get(upload_id)
+        if not meta:
+            return None
+        return deepcopy(meta)
+
+
+def reset_state() -> None:
+    """Clear stored jobs. Intended for tests."""
+
+    with _lock:
+        _jobs.clear()
+        _job_meta.clear()

--- a/backend/app/services/ingest_worker.py
+++ b/backend/app/services/ingest_worker.py
@@ -1,0 +1,313 @@
+"""Asynchronous ingest worker responsible for media processing."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections import deque
+from pathlib import Path
+from typing import Deque, Dict, Iterable, List, Optional
+
+from . import ingest_state
+
+
+LOGGER = logging.getLogger("app.ingest")
+
+DATA_ROOT = Path(os.getenv("DATA_ROOT", "/data")).resolve()
+ORIGINAL_DIR = DATA_ROOT / "original"
+MEZZ_DIR = DATA_ROOT / "mezz"
+PROXY_DIR = DATA_ROOT / "proxy"
+THUMBS_DIR = DATA_ROOT / "thumbs"
+META_DIR = DATA_ROOT / "meta"
+
+for directory in (ORIGINAL_DIR, MEZZ_DIR, PROXY_DIR, THUMBS_DIR, META_DIR):
+    directory.mkdir(parents=True, exist_ok=True)
+
+
+STAGE_PROGRESS = {
+    "validate": 5,
+    "transcode_mezz": 60,
+    "make_proxy": 80,
+    "thumbs": 95,
+    "ready": 100,
+}
+
+_tasks: Dict[str, asyncio.Task[None]] = {}
+_tasks_lock = asyncio.Lock()
+
+
+class CommandError(RuntimeError):
+    """Exception raised when ffmpeg/ffprobe command fails."""
+
+    def __init__(self, command: Iterable[str], returncode: int, stderr: Iterable[str]):
+        super().__init__(f"Command {' '.join(command)} failed with exit code {returncode}")
+        self.command = list(command)
+        self.returncode = returncode
+        self.stderr = list(stderr)
+
+
+async def _drain_stderr(stream: Optional[asyncio.StreamReader], upload_id: str, stage: str) -> List[str]:
+    if stream is None:
+        return []
+    tail: Deque[str] = deque(maxlen=40)
+    while True:
+        line = await stream.readline()
+        if not line:
+            break
+        text = line.decode(errors="replace").rstrip()
+        if text:
+            LOGGER.debug("[%s][%s] %s", upload_id, stage, text)
+            tail.append(text)
+    return list(tail)
+
+
+async def _drain_stdout(stream: Optional[asyncio.StreamReader]) -> bytes:
+    if stream is None:
+        return b""
+    chunks: List[bytes] = []
+    while True:
+        chunk = await stream.read(32 * 1024)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _run_command(
+    command: List[str],
+    upload_id: str,
+    stage: str,
+    *,
+    capture_stdout: bool = False,
+) -> bytes:
+    stdout_pipe = asyncio.subprocess.PIPE if capture_stdout else asyncio.subprocess.DEVNULL
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=stdout_pipe,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout_task = (
+        asyncio.create_task(_drain_stdout(process.stdout)) if capture_stdout else None
+    )
+    stderr_task = asyncio.create_task(_drain_stderr(process.stderr, upload_id, stage))
+
+    returncode = await process.wait()
+    stderr_lines = await stderr_task
+    stdout_bytes = await stdout_task if stdout_task else b""
+
+    if returncode != 0:
+        raise CommandError(command, returncode, stderr_lines)
+
+    return stdout_bytes
+
+
+def _gpu_enabled() -> bool:
+    return os.getenv("USE_GPU", "false").lower() in {"1", "true", "yes", "on"}
+
+
+def _build_asset_urls(upload_id: str) -> Dict[str, str]:
+    return {
+        "mezzanine_url": f"/assets/mezz/{upload_id}.mp4",
+        "proxy_url": f"/assets/proxy/{upload_id}.mp4",
+        "thumbs_glob": f"/assets/thumbs/{upload_id}/thumb_%04d.jpg",
+        "keyframes_csv": f"/assets/meta/{upload_id}/keyframes.csv",
+    }
+
+
+async def is_job_running(upload_id: str) -> bool:
+    async with _tasks_lock:
+        task = _tasks.get(upload_id)
+        return bool(task) and not task.done()
+
+
+async def register_task(upload_id: str, task: asyncio.Task[None]) -> None:
+    async with _tasks_lock:
+        _tasks[upload_id] = task
+
+    def _cleanup(_task: asyncio.Task[None]) -> None:
+        async def _inner() -> None:
+            async with _tasks_lock:
+                existing = _tasks.get(upload_id)
+                if existing is _task:
+                    _tasks.pop(upload_id, None)
+
+        asyncio.create_task(_inner())
+
+    task.add_done_callback(_cleanup)
+
+
+async def run_ingest(upload_id: str, src_path: str, ext: str) -> None:
+    """Execute ingest pipeline for a given upload identifier."""
+
+    LOGGER.info("Starting ingest for %s", upload_id)
+
+    progress = 0
+    use_gpu = _gpu_enabled()
+
+    try:
+        ingest_state.update_job(upload_id, status="running", stage="validate", progress=1, message=None)
+        progress = 1
+
+        probe_cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_streams",
+            "-of",
+            "json",
+            src_path,
+        ]
+        probe_output = await _run_command(probe_cmd, upload_id, "validate", capture_stdout=True)
+        streams = json.loads(probe_output.decode() or "{}").get("streams", [])
+        video_streams = [stream for stream in streams if stream.get("codec_type") == "video"]
+        if not video_streams:
+            raise RuntimeError("No video streams detected during validation")
+
+        progress = STAGE_PROGRESS["validate"]
+        ingest_state.update_job(upload_id, status="running", stage="transcode_mezz", progress=progress)
+
+        mezz_path = MEZZ_DIR / f"{upload_id}.mp4"
+        proxy_path = PROXY_DIR / f"{upload_id}.mp4"
+        thumbs_path = THUMBS_DIR / upload_id
+        meta_path = META_DIR / upload_id
+        thumbs_path.mkdir(parents=True, exist_ok=True)
+        meta_path.mkdir(parents=True, exist_ok=True)
+
+        hw_accel = ["-hwaccel", "cuda"] if use_gpu else []
+        if use_gpu:
+            vcodec_args = ["-c:v", "h264_nvenc"]
+        else:
+            vcodec_args = ["-c:v", "libx264", "-pix_fmt", "yuv420p"]
+
+        mezz_cmd = [
+            "ffmpeg",
+            "-y",
+            *hw_accel,
+            "-i",
+            src_path,
+            "-vf",
+            "scale=-2:1080,fps=30,format=yuv420p",
+            *vcodec_args,
+            "-preset",
+            "p5",
+            "-profile:v",
+            "high",
+            "-b:v",
+            "10M",
+            "-maxrate",
+            "12M",
+            "-bufsize",
+            "20M",
+            "-g",
+            "60",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "96k",
+            "-ar",
+            "48000",
+            "-ac",
+            "1",
+            str(mezz_path),
+        ]
+        await _run_command(mezz_cmd, upload_id, "transcode_mezz")
+
+        assets = _build_asset_urls(upload_id)
+        progress = STAGE_PROGRESS["transcode_mezz"]
+        ingest_state.update_job(
+            upload_id,
+            status="running",
+            stage="make_proxy",
+            progress=progress,
+            assets={"mezzanine_url": assets["mezzanine_url"]},
+        )
+
+        proxy_cmd = [
+            "ffmpeg",
+            "-y",
+            *hw_accel,
+            "-i",
+            src_path,
+            "-vf",
+            "scale=-2:720,fps=30,format=yuv420p",
+            *vcodec_args,
+            "-preset",
+            "p5",
+            "-b:v",
+            "4M",
+            "-g",
+            "60",
+            "-an",
+            str(proxy_path),
+        ]
+        await _run_command(proxy_cmd, upload_id, "make_proxy")
+
+        progress = STAGE_PROGRESS["make_proxy"]
+        ingest_state.update_job(
+            upload_id,
+            status="running",
+            stage="thumbs",
+            progress=progress,
+            assets={"proxy_url": assets["proxy_url"]},
+        )
+
+        thumbs_cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(mezz_path),
+            "-vf",
+            "fps=1,scale=-2:180",
+            str(thumbs_path / "thumb_%04d.jpg"),
+        ]
+        await _run_command(thumbs_cmd, upload_id, "thumbs")
+
+        progress = STAGE_PROGRESS["thumbs"]
+        ingest_state.update_job(upload_id, status="running", stage="thumbs", progress=progress)
+
+        keyframe_cmd = [
+            "ffprobe",
+            "-select_streams",
+            "v",
+            "-show_frames",
+            "-show_entries",
+            "frame=pkt_pts_time,pict_type",
+            "-of",
+            "csv",
+            str(mezz_path),
+        ]
+        keyframe_output = await _run_command(keyframe_cmd, upload_id, "thumbs", capture_stdout=True)
+        (meta_path / "keyframes.csv").write_bytes(keyframe_output)
+
+        progress = STAGE_PROGRESS["ready"]
+        ingest_state.update_job(
+            upload_id,
+            status="ready",
+            stage="ready",
+            progress=progress,
+            assets={
+                "mezzanine_url": assets["mezzanine_url"],
+                "proxy_url": assets["proxy_url"],
+                "thumbs_glob": assets["thumbs_glob"],
+                "keyframes_csv": assets["keyframes_csv"],
+            },
+        )
+        LOGGER.info("Ingest complete for %s", upload_id)
+    except Exception as exc:  # pylint: disable=broad-except
+        error_message = None
+        if isinstance(exc, CommandError):
+            tail = "\n".join(exc.stderr[-10:])
+            error_message = tail or str(exc)
+        else:
+            error_message = str(exc)
+        LOGGER.error("Ingest failed for %s: %s", upload_id, error_message)
+        ingest_state.update_job(
+            upload_id,
+            status="error",
+            stage="error",
+            progress=progress,
+            message=error_message,
+        )
+        raise

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -4,18 +4,18 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.routers import ingest as upload_ingest
 from app.services import ingest as legacy_ingest_service
+from app.services import ingest_state
 
 
 @pytest.fixture(autouse=True)
 def reset_ingest_state():
     """Ensure ingest state stores do not leak between tests."""
 
-    upload_ingest._upload_store.clear()
+    ingest_state.reset_state()
     legacy_ingest_service.job_store._jobs.clear()
     yield
-    upload_ingest._upload_store.clear()
+    ingest_state.reset_state()
     legacy_ingest_service.job_store._jobs.clear()
 
 
@@ -28,7 +28,13 @@ def test_ingest_status_endpoint_returns_payload():
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"]
-    assert set(payload["assets"].keys()) == {"original_url", "proxy_url", "mezzanine_url"}
+    assert set(payload["assets"].keys()) == {
+        "original_url",
+        "proxy_url",
+        "mezzanine_url",
+        "thumbs_glob",
+        "keyframes_csv",
+    }
 
 
 def test_ingest_health_endpoint_reports_ok():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - data:/data
     environment:
       - DATA_ROOT=/data
+      - USE_GPU=true  # set to false if no NVENC
       - LLM_BASE_URL=${LLM_BASE_URL:-http://localhost:1234/v1}
       - ENABLE_TRAINER=${ENABLE_TRAINER:-true}
       - ENABLE_SCREEN_SNAP=${ENABLE_SCREEN_SNAP:-true}

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -27,14 +27,18 @@ export interface ModuleHealth {
 export interface UploadResponse {
   upload_id: string;
   original_url: string;
-  proxy_url: string;
+  proxy_url: string | null;
   mezzanine_url: string | null;
+  thumbs_glob: string | null;
+  keyframes_csv: string | null;
 }
 
 export interface UploadStatusAssets {
-  original_url: string;
-  proxy_url: string;
+  original_url: string | null;
+  proxy_url: string | null;
   mezzanine_url: string | null;
+  thumbs_glob: string | null;
+  keyframes_csv: string | null;
 }
 
 export interface UploadStatus {
@@ -42,10 +46,11 @@ export interface UploadStatus {
   stage: string;
   progress: number;
   message?: string;
-  assets?: UploadStatusAssets;
+  assets: UploadStatusAssets;
 }
 
 export const UPLOAD_STAGE_LABELS: Record<string, string> = {
+  queued: 'Queued',
   validate: 'Validating source',
   transcode_mezz: 'Transcoding mezzanine',
   make_proxy: 'Preparing proxy',


### PR DESCRIPTION
## Summary
- implement in-memory ingest job state store and async worker to generate mezzanine, proxy, thumbnails, and keyframe metadata with GPU-aware ffmpeg commands
- replace ingest router with upload/start/status endpoints that coordinate the worker, update FastAPI wiring, and extend docker-compose with GPU toggle
- update React upload dialog, types, and app shell to poll ingest progress, surface errors, and switch playback to the generated proxy asset

## Testing
- pytest
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d21916d00c832582e5d337a1ee36e7