### PR TITLE
feat: add calibration and overlay annotation tools

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from starlette.responses import Response
 
 from .api import analyze, events, exports, ingest as legacy_ingest, insights, modules, screensnap, stats, trainer
 from .config import get_settings
-from .routers import ingest, logs
+from .routers import annotations, calibration, ingest, logs
 from .services.logbuffer import LogBuffer
 from .services.loghandler import LogBufferHandler
 
@@ -62,6 +62,8 @@ app.include_router(stats.router)
 app.include_router(analyze.router)
 app.include_router(logs.router)
 app.include_router(ingest.router)
+app.include_router(annotations.router)
+app.include_router(calibration.router)
 
 if settings.feature_flags.get("exports", True):
     app.include_router(exports.router)

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,3 +1,3 @@
 """Additional API routers for VolleySense."""
 
-__all__ = ["ingest", "logs"]
+__all__ = ["annotations", "calibration", "ingest", "logs"]

--- a/backend/app/routers/annotations.py
+++ b/backend/app/routers/annotations.py
@@ -1,0 +1,88 @@
+"""Annotation persistence for overlays."""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+
+DATA_ROOT = Path(os.getenv("DATA_ROOT", "/data")).resolve()
+ANN_DIR = DATA_ROOT / "ann"
+ANN_DIR.mkdir(parents=True, exist_ok=True)
+
+
+class Rect(BaseModel):
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+class Poly(BaseModel):
+    pts: Sequence[Tuple[float, float]] = Field(..., min_length=3)
+
+
+class AnnotationPayload(BaseModel):
+    frame_t: float
+    rect: Optional[Rect] = None
+    poly: Optional[Poly] = None
+    jersey: Optional[int] = None
+    label: Optional[str] = None
+    notes: Optional[str] = None
+
+    def validate_geometry(self) -> None:
+        if not self.rect and not self.poly:
+            raise HTTPException(status_code=400, detail="Annotation requires rect or poly geometry")
+
+
+router = APIRouter(prefix="/annotations", tags=["annotations"])
+
+
+def _annotation_path(upload_id: str) -> Path:
+    safe_id = upload_id.replace("/", "_")
+    return ANN_DIR / f"{safe_id}.jsonl"
+
+
+def _load_annotations(upload_id: str) -> List[dict]:
+    path = _annotation_path(upload_id)
+    if not path.exists():
+        return []
+    records: List[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+@router.get("/{upload_id}")
+def list_annotations(upload_id: str) -> List[dict]:
+    return _load_annotations(upload_id)
+
+
+@router.post("/{upload_id}")
+def create_annotation(upload_id: str, payload: AnnotationPayload) -> dict:
+    payload.validate_geometry()
+
+    record = payload.model_dump()
+    record["id"] = str(uuid.uuid4())
+    record["created_at"] = datetime.now(timezone.utc).isoformat()
+
+    path = _annotation_path(upload_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record))
+        handle.write("\n")
+
+    return record

--- a/backend/app/routers/calibration.py
+++ b/backend/app/routers/calibration.py
@@ -1,0 +1,123 @@
+"""Routes for storing and applying court calibration."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import List, Literal, Sequence, Tuple
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field, ValidationError
+
+from app.services.homography import apply_h, compute_h, invert_h
+
+
+DATA_ROOT = Path(os.getenv("DATA_ROOT", "/data")).resolve()
+CALIB_DIR = DATA_ROOT / "calib"
+CALIB_DIR.mkdir(parents=True, exist_ok=True)
+
+CourtPoint = Tuple[float, float]
+
+COURT_TEMPLATE_POINTS: List[CourtPoint] = [
+    (0.0, 0.0),  # left-near
+    (18.0, 0.0),  # right-near
+    (18.0, 9.0),  # right-far
+    (0.0, 9.0),  # left-far
+]
+
+
+class CalibrationPayload(BaseModel):
+    frame_t: float = Field(..., description="Timestamp of the frame used for calibration")
+    image_size: Tuple[int, int] = Field(..., description="Width/height of the source frame")
+    image_points: Sequence[Tuple[float, float]] = Field(
+        ..., min_length=4, max_length=4, description="Court corner clicks in image space"
+    )
+    court_template: Literal["indoor_fivb_18x9"] = Field(
+        "indoor_fivb_18x9", description="Court template identifier"
+    )
+    net_points: Sequence[Tuple[float, float]] = Field(
+        ..., min_length=2, max_length=2, description="Net tape clicks in image space"
+    )
+
+
+class TransformRequest(BaseModel):
+    pts: Sequence[Tuple[float, float]] = Field(..., min_length=1)
+
+
+router = APIRouter(prefix="/calibration", tags=["calibration"])
+
+
+def _calibration_path(upload_id: str) -> Path:
+    safe_id = upload_id.replace("/", "_")
+    return CALIB_DIR / f"{safe_id}.json"
+
+
+def _load_calibration(upload_id: str) -> dict:
+    path = _calibration_path(upload_id)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Calibration not found")
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@router.post("/{upload_id}")
+def save_calibration(upload_id: str, payload: CalibrationPayload) -> dict:
+    image_points = [tuple(point) for point in payload.image_points]
+    court_points: List[CourtPoint] = COURT_TEMPLATE_POINTS.copy()
+
+    try:
+        homography = compute_h(image_points, court_points)
+    except (ValueError, ValidationError) as exc:  # pragma: no cover - validation duplicates
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        homography_inv = invert_h(homography)
+    except Exception as exc:  # pragma: no cover - matrix inversion should succeed
+        raise HTTPException(status_code=400, detail="Homography inversion failed") from exc
+
+    net_points = [tuple(point) for point in payload.net_points]
+    net_court = apply_h(homography, net_points)
+
+    record = {
+        "frame_t": payload.frame_t,
+        "image_size": list(payload.image_size),
+        "image_points": [list(point) for point in image_points],
+        "court_template": payload.court_template,
+        "court_points": [list(point) for point in court_points],
+        "net_points": [list(point) for point in net_points],
+        "net_court_points": [list(point) for point in net_court],
+        "homography": homography,
+        "homography_inv": homography_inv,
+    }
+
+    path = _calibration_path(upload_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(record, handle, indent=2)
+
+    return record
+
+
+@router.get("/{upload_id}")
+def get_calibration(upload_id: str) -> dict:
+    return _load_calibration(upload_id)
+
+
+@router.post("/{upload_id}/pixel_to_court")
+def pixel_to_court(upload_id: str, payload: TransformRequest) -> dict:
+    calibration = _load_calibration(upload_id)
+    matrix = calibration.get("homography")
+    if not matrix:
+        raise HTTPException(status_code=400, detail="Calibration missing homography")
+    transformed = apply_h(matrix, payload.pts)
+    return {"uv": [list(point) for point in transformed]}
+
+
+@router.post("/{upload_id}/court_to_pixel")
+def court_to_pixel(upload_id: str, payload: TransformRequest) -> dict:
+    calibration = _load_calibration(upload_id)
+    matrix = calibration.get("homography_inv")
+    if not matrix:
+        raise HTTPException(status_code=400, detail="Calibration missing inverse homography")
+    transformed = apply_h(matrix, payload.pts)
+    return {"px": [list(point) for point in transformed]}

--- a/backend/app/services/homography.py
+++ b/backend/app/services/homography.py
@@ -1,0 +1,98 @@
+"""Homography helpers for transforming between image and court coordinates."""
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence, Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import cv2  # type: ignore
+
+    _HAS_CV2 = True
+except Exception:  # pragma: no cover - we fall back to numpy implementation
+    cv2 = None  # type: ignore
+    _HAS_CV2 = False
+
+
+Point = Tuple[float, float]
+
+
+def _validate_points(points: Sequence[Sequence[float]]) -> np.ndarray:
+    if len(points) < 4:
+        raise ValueError("At least four points are required to compute a homography")
+    array = np.asarray(points, dtype=float)
+    if array.shape[1] != 2:
+        raise ValueError("Points must be 2D coordinates")
+    return array
+
+
+def compute_h(image_pts: Sequence[Sequence[float]], court_pts: Sequence[Sequence[float]]) -> List[List[float]]:
+    """Compute the planar homography mapping image points to court coordinates.
+
+    Parameters
+    ----------
+    image_pts:
+        Sequence of 2D image coordinates (pixels).
+    court_pts:
+        Sequence of corresponding 2D court coordinates (meters).
+
+    Returns
+    -------
+    list[list[float]]
+        A 3x3 homography matrix (row-major) that maps image coordinates to court
+        coordinates.
+    """
+
+    src = _validate_points(image_pts)
+    dst = _validate_points(court_pts)
+    if src.shape[0] != dst.shape[0]:
+        raise ValueError("Image points and court points must have the same length")
+
+    if _HAS_CV2:
+        matrix, status = cv2.findHomography(src, dst, method=0)  # type: ignore[arg-type]
+        if matrix is None or (status is not None and not status.any()):
+            raise ValueError("Failed to compute homography with OpenCV")
+        return matrix.tolist()
+
+    # Direct Linear Transform (DLT) implementation
+    num_points = src.shape[0]
+    a_matrix = []
+    for i in range(num_points):
+        x, y = src[i]
+        u, v = dst[i]
+        a_matrix.append([-x, -y, -1.0, 0.0, 0.0, 0.0, u * x, u * y, u])
+        a_matrix.append([0.0, 0.0, 0.0, -x, -y, -1.0, v * x, v * y, v])
+
+    a = np.asarray(a_matrix, dtype=float)
+
+    # Solve Ah = 0 subject to ||h|| = 1 via SVD. The solution is the singular
+    # vector corresponding to the smallest singular value.
+    _, _, vh = np.linalg.svd(a)
+    h = vh[-1, :]
+    h = h / h[-1]
+    matrix = h.reshape((3, 3))
+    return matrix.tolist()
+
+
+def apply_h(matrix: Sequence[Sequence[float]], points: Iterable[Point]) -> List[Point]:
+    """Apply a homography matrix to a set of points."""
+
+    mat = np.asarray(matrix, dtype=float)
+    pts = np.asarray(list(points), dtype=float)
+    if pts.size == 0:
+        return []
+
+    ones = np.ones((pts.shape[0], 1), dtype=float)
+    homo = np.hstack([pts, ones])
+    transformed = (mat @ homo.T).T
+    transformed /= transformed[:, 2:3]
+    return [(float(x), float(y)) for x, y in transformed[:, :2]]
+
+
+def invert_h(matrix: Sequence[Sequence[float]]) -> List[List[float]]:
+    """Return the inverse homography matrix."""
+
+    mat = np.asarray(matrix, dtype=float)
+    inv = np.linalg.inv(mat)
+    inv /= inv[2, 2]
+    return inv.tolist()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,5 @@ pydantic-settings==2.3.4
 httpx==0.27.2
 pytest==8.3.3
 python-multipart==0.0.9
+numpy==1.26.4
+opencv-python-headless==4.10.0.84

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,12 +11,14 @@
         "@headlessui/react": "^1.7.17",
         "lucide-react": "^0.304.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.4.3",
+        "@types/jest": "^30.0.0",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "@typescript-eslint/eslint-plugin": "^6.13.2",
@@ -955,6 +957,53 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.2.tgz",
+      "integrity": "sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -967,6 +1016,45 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
+      "integrity": "sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -1298,6 +1386,99 @@
         "@types/chai": "<5.2.0"
       }
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1319,14 +1500,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1347,6 +1528,30 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2266,6 +2471,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2388,7 +2609,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3002,6 +3223,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expect": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
+      "integrity": "sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.1.2",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.1.2",
+        "jest-message-util": "30.1.0",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3401,6 +3640,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3981,6 +4227,280 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
+      "integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
+      "integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.1.0.tgz",
+      "integrity": "sha512-HizKDGG98cYkWmaLUHChq4iN+oCENohQLb7Z5guBPumYs+/etonmNFlg1Ps6yN9LTPyZn+M+b/9BbnHx3WTMDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.0.5",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.0.5",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-mock": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
+      "integrity": "sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
+      "integrity": "sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/jiti": {
@@ -5474,6 +5994,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6014,6 +6557,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6521,6 +7073,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -14,16 +14,19 @@
     "@headlessui/react": "^1.7.17",
     "lucide-react": "^0.304.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^30.0.0",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "@typescript-eslint/parser": "^6.13.2",
+    "@vitejs/plugin-react": "^4.1.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.55.0",
     "eslint-config-prettier": "^9.0.0",
@@ -35,7 +38,6 @@
     "tailwindcss": "^3.3.3",
     "typescript": "^5.2.2",
     "vite": "^4.5.0",
-    "vitest": "^0.34.6",
-    "@vitejs/plugin-react": "^4.1.0"
+    "vitest": "^0.34.6"
   }
 }

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -25,7 +25,18 @@ type FetchArgs = [input: RequestInfo | URL, init?: RequestInit];
 beforeEach(() => {
   vi.spyOn(globalThis, 'fetch').mockImplementation(async (...args: FetchArgs) => {
     const [input] = args;
-    const url = typeof input === 'string' ? input : input.url;
+    let url: string;
+    if (typeof input === 'string') {
+      url = input;
+    } else if (input instanceof URL) {
+      url = input.toString();
+    } else if (typeof Request !== 'undefined' && input instanceof Request) {
+      url = input.url;
+    } else if (typeof (input as { url?: string }).url === 'string') {
+      url = (input as { url: string }).url;
+    } else {
+      url = String(input);
+    }
     if (url.endsWith('/events')) {
       return new Response(JSON.stringify(eventsPayload), { status: 200 });
     }

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 
 interface ErrorBoundaryState {
   hasError: boolean;
   message?: string;
 }
 
-export class ErrorBoundary extends React.Component<{ label: string }, ErrorBoundaryState> {
-  constructor(props: { label: string }) {
+type ErrorBoundaryProps = PropsWithChildren<{ label: string }>;
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false };
   }

--- a/web/src/components/OverlayCanvas.tsx
+++ b/web/src/components/OverlayCanvas.tsx
@@ -1,0 +1,573 @@
+import React, { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
+
+import { OverlayTool } from '../hooks/useOverlayTool';
+
+export interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface Poly {
+  pts: [number, number][];
+}
+
+export interface AnnotationInput {
+  frame_t: number;
+  rect?: Rect;
+  poly?: Poly;
+  jersey?: number;
+  label?: string;
+  notes?: string;
+}
+
+export interface AnnotationRecord extends AnnotationInput {
+  id: string;
+  created_at?: string;
+}
+
+export interface CalibrationData {
+  frame_t: number;
+  image_size: [number, number];
+  image_points: [number, number][];
+  court_template: string;
+  court_points: [number, number][];
+  net_points: [number, number][];
+  net_court_points?: [number, number][];
+  homography: number[][];
+  homography_inv: number[][];
+}
+
+interface OverlayCanvasProps {
+  videoRef: MutableRefObject<HTMLVideoElement | null>;
+  mode: OverlayTool;
+  uploadId?: string | null;
+  annotations: AnnotationRecord[];
+  onCreate: (payload: AnnotationInput) => Promise<AnnotationRecord | null>;
+  calibration?: CalibrationData | null;
+  pixelToCourt?: ((x: number, y: number) => [number, number] | null) | null;
+  courtToPixel?: ((u: number, v: number) => [number, number] | null) | null;
+}
+
+interface LayoutMetrics {
+  videoWidth: number;
+  videoHeight: number;
+  displayWidth: number;
+  displayHeight: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+interface DraftRect {
+  start: { x: number; y: number };
+  current: { x: number; y: number };
+}
+
+const COURT_LINES: [number, number][][] = [
+  [
+    [0, 0],
+    [18, 0],
+  ],
+  [
+    [18, 0],
+    [18, 9],
+  ],
+  [
+    [18, 9],
+    [0, 9],
+  ],
+  [
+    [0, 9],
+    [0, 0],
+  ],
+  [
+    [0, 4.5],
+    [18, 4.5],
+  ],
+  [
+    [0, 1.5],
+    [18, 1.5],
+  ],
+  [
+    [0, 7.5],
+    [18, 7.5],
+  ],
+  [
+    [6, 0],
+    [6, 9],
+  ],
+  [
+    [12, 0],
+    [12, 9],
+  ],
+];
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const applyMatrix = (matrix: number[][], x: number, y: number): [number, number] | null => {
+  if (!matrix || matrix.length !== 3 || matrix[0].length !== 3) return null;
+  const [m0, m1, m2] = matrix;
+  const denom = m2[0] * x + m2[1] * y + m2[2];
+  if (Math.abs(denom) < 1e-6) return null;
+  const px = (m0[0] * x + m0[1] * y + m0[2]) / denom;
+  const py = (m1[0] * x + m1[1] * y + m1[2]) / denom;
+  return [px, py];
+};
+
+const formatZoneLabel = (u: number, v: number): string => {
+  const horizontal = u < 6 ? 'Left' : u < 12 ? 'Center' : 'Right';
+  const depth = v < 4.5 ? 'Near' : 'Far';
+  return `${depth} ${horizontal}`;
+};
+
+export const OverlayCanvas: React.FC<OverlayCanvasProps> = ({
+  videoRef,
+  mode,
+  uploadId,
+  annotations,
+  onCreate,
+  calibration,
+  pixelToCourt,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [layout, setLayout] = useState<LayoutMetrics | null>(null);
+  const [draftRect, setDraftRect] = useState<DraftRect | null>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notes, setNotes] = useState('');
+  const [jersey, setJersey] = useState('');
+  const [label, setLabel] = useState<'serve' | 'set' | 'attack' | 'block' | 'dig' | 'custom'>('serve');
+  const [customLabel, setCustomLabel] = useState('');
+  const [previewZone, setPreviewZone] = useState<string | null>(null);
+
+  const syncLayout = useCallback(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    const video = videoRef.current;
+    if (!container || !canvas || !video) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const videoRect = video.getBoundingClientRect();
+
+    const metrics: LayoutMetrics = {
+      videoWidth: video.videoWidth || 0,
+      videoHeight: video.videoHeight || 0,
+      displayWidth: videoRect.width,
+      displayHeight: videoRect.height,
+      offsetX: videoRect.left - containerRect.left,
+      offsetY: videoRect.top - containerRect.top,
+    };
+
+    setLayout(metrics);
+    canvas.width = Math.round(containerRect.width);
+    canvas.height = Math.round(containerRect.height);
+  }, [videoRef]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return undefined;
+
+    const handleMetadata = () => syncLayout();
+    const handleResize = () => syncLayout();
+    const handleTimeUpdate = () => syncLayout();
+
+    video.addEventListener('loadedmetadata', handleMetadata);
+    video.addEventListener('timeupdate', handleTimeUpdate);
+    window.addEventListener('resize', handleResize);
+
+    syncLayout();
+
+    return () => {
+      video.removeEventListener('loadedmetadata', handleMetadata);
+      video.removeEventListener('timeupdate', handleTimeUpdate);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [videoRef, syncLayout]);
+
+  const clearDraft = useCallback(() => {
+    setIsDrawing(false);
+    setDraftRect(null);
+    setPreviewZone(null);
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        clearDraft();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [clearDraft]);
+
+  const imageToDisplay = useCallback(
+    (x: number, y: number) => {
+      if (!layout || !layout.videoWidth || !layout.videoHeight) return null;
+      const px = layout.offsetX + (x / layout.videoWidth) * layout.displayWidth;
+      const py = layout.offsetY + (y / layout.videoHeight) * layout.displayHeight;
+      return { x: px, y: py };
+    },
+    [layout],
+  );
+
+  const normalizedToImage = useCallback(
+    (rect: Rect) => {
+      if (!layout || !layout.videoWidth || !layout.videoHeight) return null;
+      return {
+        x: rect.x * layout.videoWidth,
+        y: rect.y * layout.videoHeight,
+        w: rect.w * layout.videoWidth,
+        h: rect.h * layout.videoHeight,
+      };
+    },
+    [layout],
+  );
+
+  const getImageCoords = useCallback(
+    (event: PointerEvent) => {
+      const container = containerRef.current;
+      const currentLayout = layout;
+      if (!container || !currentLayout) return null;
+
+      const rect = container.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+
+      const relX = x - currentLayout.offsetX;
+      const relY = y - currentLayout.offsetY;
+
+      if (
+        relX < 0 ||
+        relY < 0 ||
+        relX > currentLayout.displayWidth ||
+        relY > currentLayout.displayHeight
+      ) {
+        return null;
+      }
+
+      const imageX = (relX / (currentLayout.displayWidth || 1)) * currentLayout.videoWidth;
+      const imageY = (relY / (currentLayout.displayHeight || 1)) * currentLayout.videoHeight;
+      return { x: imageX, y: imageY };
+    },
+    [layout],
+  );
+
+  const renderOverlay = useCallback(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext('2d');
+    if (!canvas || !context) return;
+    context.clearRect(0, 0, canvas.width, canvas.height);
+
+    if (!layout || !layout.videoWidth || !layout.videoHeight) {
+      return;
+    }
+
+    const drawRect = (rect: Rect, color: string) => {
+      const imgRect = normalizedToImage(rect);
+      if (!imgRect) return;
+      const start = imageToDisplay(imgRect.x, imgRect.y);
+      if (!start) return;
+      const end = imageToDisplay(imgRect.x + imgRect.w, imgRect.y + imgRect.h);
+      if (!end) return;
+      context.save();
+      context.strokeStyle = color;
+      context.lineWidth = 2;
+      context.strokeRect(start.x, start.y, end.x - start.x, end.y - start.y);
+      context.restore();
+    };
+
+    const drawPoly = (poly: Poly, color: string) => {
+      const points = poly.pts
+        .map(([nx, ny]) => {
+          const x = nx * layout.videoWidth;
+          const y = ny * layout.videoHeight;
+          return imageToDisplay(x, y);
+        })
+        .filter(Boolean) as { x: number; y: number }[];
+      if (points.length < 2) return;
+      context.save();
+      context.strokeStyle = color;
+      context.lineWidth = 2;
+      context.beginPath();
+      context.moveTo(points[0].x, points[0].y);
+      for (let i = 1; i < points.length; i += 1) {
+        context.lineTo(points[i].x, points[i].y);
+      }
+      context.closePath();
+      context.stroke();
+      context.restore();
+    };
+
+    if (calibration) {
+      context.save();
+      context.strokeStyle = 'rgba(148, 163, 184, 0.35)';
+      context.lineWidth = 1.5;
+
+      for (const [[ux0, uy0], [ux1, uy1]] of COURT_LINES) {
+        const startCourt = applyMatrix(calibration.homography_inv, ux0, uy0);
+        const endCourt = applyMatrix(calibration.homography_inv, ux1, uy1);
+        if (!startCourt || !endCourt) continue;
+        const start = imageToDisplay(startCourt[0], startCourt[1]);
+        const end = imageToDisplay(endCourt[0], endCourt[1]);
+        if (!start || !end) continue;
+        context.beginPath();
+        context.moveTo(start.x, start.y);
+        context.lineTo(end.x, end.y);
+        context.stroke();
+      }
+
+      if (calibration.net_points?.length === 2) {
+        const [n0, n1] = calibration.net_points;
+        const start = imageToDisplay(n0[0], n0[1]);
+        const end = imageToDisplay(n1[0], n1[1]);
+        if (start && end) {
+          context.strokeStyle = 'rgba(56, 189, 248, 0.6)';
+          context.lineWidth = 2;
+          context.beginPath();
+          context.moveTo(start.x, start.y);
+          context.lineTo(end.x, end.y);
+          context.stroke();
+        }
+      }
+      context.restore();
+    }
+
+    for (const annotation of annotations) {
+      if (annotation.rect) {
+        drawRect(annotation.rect, 'rgba(16, 185, 129, 0.85)');
+      }
+      if (annotation.poly) {
+        drawPoly(annotation.poly, 'rgba(250, 204, 21, 0.85)');
+      }
+    }
+
+    if (draftRect) {
+      const start = imageToDisplay(draftRect.start.x, draftRect.start.y);
+      const current = imageToDisplay(draftRect.current.x, draftRect.current.y);
+      if (start && current) {
+        context.save();
+        context.strokeStyle = 'rgba(59, 130, 246, 0.9)';
+        context.setLineDash([6, 3]);
+        context.strokeRect(start.x, start.y, current.x - start.x, current.y - start.y);
+        context.restore();
+      }
+    }
+  }, [annotations, calibration, draftRect, imageToDisplay, layout, normalizedToImage]);
+
+  useEffect(() => {
+    renderOverlay();
+  }, [renderOverlay]);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (mode !== 'box') return;
+      if (!uploadId) {
+        setError('Annotations require an active upload.');
+        return;
+      }
+      const coords = getImageCoords(event.nativeEvent);
+      if (!coords) {
+        return;
+      }
+      setError(null);
+      setIsDrawing(true);
+      setDraftRect({ start: coords, current: coords });
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [getImageCoords, mode, uploadId],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!isDrawing || !draftRect) return;
+      const coords = getImageCoords(event.nativeEvent);
+      if (!coords) return;
+      setDraftRect((prev) => (prev ? { start: prev.start, current: coords } : prev));
+      const transform = pixelToCourt
+        ? pixelToCourt
+        : calibration
+        ? (px: number, py: number) => applyMatrix(calibration.homography, px, py)
+        : null;
+      if (transform && layout) {
+        const centerX = (draftRect.start.x + coords.x) / 2;
+        const centerY = (draftRect.start.y + coords.y) / 2;
+        const court = transform(centerX, centerY);
+        if (court) {
+          setPreviewZone(formatZoneLabel(court[0], court[1]));
+        }
+      }
+    },
+    [calibration, draftRect, getImageCoords, isDrawing, layout, pixelToCourt],
+  );
+
+  const finishRect = useCallback(
+    async (endPoint: { x: number; y: number } | null) => {
+      if (!draftRect || !layout || !layout.videoWidth || !layout.videoHeight) {
+        clearDraft();
+        return;
+      }
+      const end = endPoint ?? draftRect.current;
+      const x0 = clamp(Math.min(draftRect.start.x, end.x), 0, layout.videoWidth);
+      const y0 = clamp(Math.min(draftRect.start.y, end.y), 0, layout.videoHeight);
+      const x1 = clamp(Math.max(draftRect.start.x, end.x), 0, layout.videoWidth);
+      const y1 = clamp(Math.max(draftRect.start.y, end.y), 0, layout.videoHeight);
+
+      const width = x1 - x0;
+      const height = y1 - y0;
+
+      if (width < 4 || height < 4) {
+        clearDraft();
+        return;
+      }
+
+      const normalized: Rect = {
+        x: x0 / layout.videoWidth,
+        y: y0 / layout.videoHeight,
+        w: width / layout.videoWidth,
+        h: height / layout.videoHeight,
+      };
+
+      const labelValue = label === 'custom' ? customLabel.trim() : label;
+      const jerseyValue = jersey.trim();
+      const notesValue = notes.trim();
+
+      const payload: AnnotationInput = {
+        frame_t: videoRef.current?.currentTime ?? 0,
+        rect: normalized,
+        label: labelValue ? labelValue : undefined,
+        jersey: jerseyValue ? Number(jerseyValue) : undefined,
+        notes: notesValue ? notesValue : undefined,
+      };
+
+      try {
+        await onCreate(payload);
+        const transform = pixelToCourt
+          ? pixelToCourt
+          : calibration
+          ? (px: number, py: number) => applyMatrix(calibration.homography, px, py)
+          : null;
+        if (transform) {
+          const centerX = x0 + width / 2;
+          const centerY = y0 + height / 2;
+          const court = transform(centerX, centerY);
+          if (court) {
+            setPreviewZone(formatZoneLabel(court[0], court[1]));
+          } else {
+            setPreviewZone(null);
+          }
+        }
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        clearDraft();
+      }
+    },
+    [calibration, clearDraft, customLabel, jersey, label, layout, notes, onCreate, videoRef],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!isDrawing) return;
+      const coords = getImageCoords(event.nativeEvent);
+      setIsDrawing(false);
+      event.currentTarget.releasePointerCapture(event.pointerId);
+      finishRect(coords);
+    },
+    [finishRect, getImageCoords, isDrawing],
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    if (isDrawing) {
+      finishRect(null);
+    }
+  }, [finishRect, isDrawing]);
+
+  const disableInteraction = mode === 'lasso';
+
+  const currentZone = previewZone;
+
+  return (
+    <div
+      ref={containerRef}
+      className="pointer-events-auto absolute inset-0"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerLeave={handlePointerLeave}
+      style={{ cursor: mode === 'box' ? 'crosshair' : 'default' }}
+    >
+      <canvas ref={canvasRef} className="absolute inset-0 h-full w-full" />
+      <div className="pointer-events-none absolute inset-0 bg-transparent" />
+      <div className="pointer-events-auto absolute bottom-4 left-4 w-72 rounded-lg border border-slate-700/60 bg-slate-900/90 p-4 text-xs shadow-lg backdrop-blur">
+        <div className="flex items-center justify-between text-slate-300">
+          <span className="font-semibold uppercase tracking-wide">Annotation Tags</span>
+          <span className="text-[10px] uppercase text-slate-500">{mode.toUpperCase()}</span>
+        </div>
+        {!uploadId && (
+          <p className="mt-2 text-[11px] text-amber-400">
+            Upload a clip to enable saving annotations.
+          </p>
+        )}
+        {disableInteraction && (
+          <p className="mt-2 text-[11px] text-slate-400">Lasso tool coming soon.</p>
+        )}
+        <div className="mt-3 space-y-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase text-slate-500">Jersey #</span>
+            <input
+              type="number"
+              value={jersey}
+              onChange={(event) => setJersey(event.target.value)}
+              className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-200 focus:border-brand focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase text-slate-500">Label</span>
+            <select
+              value={label}
+              onChange={(event) => setLabel(event.target.value as typeof label)}
+              className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-200 focus:border-brand focus:outline-none"
+            >
+              <option value="serve">Serve</option>
+              <option value="set">Set</option>
+              <option value="attack">Attack</option>
+              <option value="block">Block</option>
+              <option value="dig">Dig</option>
+              <option value="custom">Custom…</option>
+            </select>
+            {label === 'custom' && (
+              <input
+                type="text"
+                value={customLabel}
+                onChange={(event) => setCustomLabel(event.target.value)}
+                placeholder="Custom label"
+                className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-200 focus:border-brand focus:outline-none"
+              />
+            )}
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase text-slate-500">Notes</span>
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              rows={2}
+              className="rounded border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-200 focus:border-brand focus:outline-none"
+            />
+          </label>
+        </div>
+        {currentZone && (
+          <div className="mt-3 rounded border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-100">
+            Court zone: {currentZone}
+          </div>
+        )}
+        {error && (
+          <div className="mt-3 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-[11px] text-red-200">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/web/src/components/VideoViewport.tsx
+++ b/web/src/components/VideoViewport.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
+import React, { forwardRef, useCallback, useImperativeHandle, useMemo, useRef } from 'react';
 
 export interface VideoViewportHandle {
   captureStill: () => string | null;
@@ -7,62 +7,78 @@ export interface VideoViewportHandle {
 interface VideoViewportProps {
   src?: string;
   poster?: string;
+  videoRef?: React.Ref<HTMLVideoElement>;
 }
 
-export const VideoViewport = forwardRef<VideoViewportHandle, VideoViewportProps>(({ src, poster }, ref) => {
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
-  const captureCanvasRef = useRef<HTMLCanvasElement>(null);
+export const VideoViewport = forwardRef<VideoViewportHandle, VideoViewportProps>(
+  ({ src, poster, videoRef: forwardedVideoRef }, ref) => {
+    const videoRef = useRef<HTMLVideoElement | null>(null);
+    const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
+    const captureCanvasRef = useRef<HTMLCanvasElement>(null);
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      captureStill: () => {
-        const video = videoRef.current;
-        const captureCanvas = captureCanvasRef.current;
-        if (!video || !captureCanvas) return null;
-        if (!video.videoWidth || !video.videoHeight) return null;
-
-        captureCanvas.width = video.videoWidth;
-        captureCanvas.height = video.videoHeight;
-        const context = captureCanvas.getContext('2d');
-        if (!context) return null;
-
-        context.drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
-        const dataUrl = captureCanvas.toDataURL('image/jpeg', 0.9);
-        return dataUrl && dataUrl.length > 0 ? dataUrl : null;
+    const assignVideoRef = useCallback(
+      (node: HTMLVideoElement | null) => {
+        videoRef.current = node;
+        if (!forwardedVideoRef) return;
+        if (typeof forwardedVideoRef === 'function') {
+          forwardedVideoRef(node);
+        } else {
+          (forwardedVideoRef as React.MutableRefObject<HTMLVideoElement | null>).current = node;
+        }
       },
-    }),
-    [],
-  );
+      [forwardedVideoRef],
+    );
 
-  const hasSource = useMemo(() => Boolean(src), [src]);
+    useImperativeHandle(
+      ref,
+      () => ({
+        captureStill: () => {
+          const video = videoRef.current;
+          const captureCanvas = captureCanvasRef.current;
+          if (!video || !captureCanvas) return null;
+          if (!video.videoWidth || !video.videoHeight) return null;
 
-  return (
-    <div className="relative h-full w-full overflow-hidden rounded-xl border border-slate-800 bg-slate-950">
-      <video
-        ref={videoRef}
-        src={src}
-        poster={poster}
-        controls
-        playsInline
-        className="h-full w-full object-contain"
-      >
-        Your browser does not support the video tag.
-      </video>
-      <canvas
-        ref={overlayCanvasRef}
-        className="pointer-events-none absolute inset-0 h-full w-full"
-        aria-hidden="true"
-      />
-      {!hasSource && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center">
-          <div className="text-sm text-slate-400">Upload a clip to begin video analysis.</div>
-        </div>
-      )}
-      <canvas ref={captureCanvasRef} className="hidden" aria-hidden="true" />
-    </div>
-  );
-});
+          captureCanvas.width = video.videoWidth;
+          captureCanvas.height = video.videoHeight;
+          const context = captureCanvas.getContext('2d');
+          if (!context) return null;
+
+          context.drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
+          const dataUrl = captureCanvas.toDataURL('image/jpeg', 0.9);
+          return dataUrl && dataUrl.length > 0 ? dataUrl : null;
+        },
+      }),
+      [],
+    );
+
+    const hasSource = useMemo(() => Boolean(src), [src]);
+
+    return (
+      <div className="relative h-full w-full overflow-hidden rounded-xl border border-slate-800 bg-slate-950">
+        <video
+          ref={assignVideoRef}
+          src={src}
+          poster={poster}
+          controls
+          playsInline
+          className="h-full w-full object-contain"
+        >
+          Your browser does not support the video tag.
+        </video>
+        <canvas
+          ref={overlayCanvasRef}
+          className="pointer-events-none absolute inset-0 h-full w-full"
+          aria-hidden="true"
+        />
+        {!hasSource && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center">
+            <div className="text-sm text-slate-400">Upload a clip to begin video analysis.</div>
+          </div>
+        )}
+        <canvas ref={captureCanvasRef} className="hidden" aria-hidden="true" />
+      </div>
+    );
+  },
+);
 
 VideoViewport.displayName = 'VideoViewport';

--- a/web/src/hooks/useOverlayTool.ts
+++ b/web/src/hooks/useOverlayTool.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type OverlayTool = 'select' | 'box' | 'lasso';
+
+interface OverlayToolState {
+  tool: OverlayTool;
+  setTool: (tool: OverlayTool) => void;
+}
+
+export const useOverlayTool = create<OverlayToolState>()(
+  persist(
+    (set) => ({
+      tool: 'select',
+      setTool: (tool) => set({ tool }),
+    }),
+    {
+      name: 'overlay-tool',
+    },
+  ),
+);

--- a/web/src/pages/CalibrationWizard.tsx
+++ b/web/src/pages/CalibrationWizard.tsx
@@ -1,0 +1,578 @@
+import React, { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { CalibrationData } from '../components/OverlayCanvas';
+
+type WizardStep = 'frame' | 'court' | 'net' | 'confirm';
+
+interface CalibrationWizardProps {
+  open: boolean;
+  onClose: () => void;
+  videoRef: MutableRefObject<HTMLVideoElement | null>;
+  uploadId?: string | null;
+  apiBase: string;
+  onSaved: (payload: CalibrationData) => void;
+}
+
+interface Point2D {
+  x: number;
+  y: number;
+}
+
+const COURT_TEMPLATE_POINTS: [number, number][] = [
+  [0, 0],
+  [18, 0],
+  [18, 9],
+  [0, 9],
+];
+
+const COURT_LINES: [number, number][][] = [
+  [
+    [0, 0],
+    [18, 0],
+  ],
+  [
+    [18, 0],
+    [18, 9],
+  ],
+  [
+    [18, 9],
+    [0, 9],
+  ],
+  [
+    [0, 9],
+    [0, 0],
+  ],
+  [
+    [0, 4.5],
+    [18, 4.5],
+  ],
+  [
+    [0, 1.5],
+    [18, 1.5],
+  ],
+  [
+    [0, 7.5],
+    [18, 7.5],
+  ],
+  [
+    [6, 0],
+    [6, 9],
+  ],
+  [
+    [12, 0],
+    [12, 9],
+  ],
+];
+
+const CORNER_LABELS = ['Left near', 'Right near', 'Right far', 'Left far'];
+
+export const CalibrationWizard: React.FC<CalibrationWizardProps> = ({
+  open,
+  onClose,
+  videoRef,
+  uploadId,
+  apiBase,
+  onSaved,
+}) => {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const imageRef = useRef<HTMLImageElement>(null);
+  const [step, setStep] = useState<WizardStep>('frame');
+  const [frameImage, setFrameImage] = useState<string | null>(null);
+  const [frameTime, setFrameTime] = useState<number>(0);
+  const [imageSize, setImageSize] = useState<[number, number] | null>(null);
+  const [cornerPoints, setCornerPoints] = useState<Point2D[]>([]);
+  const [netPoints, setNetPoints] = useState<Point2D[]>([]);
+  const [previewMatrix, setPreviewMatrix] = useState<number[][] | null>(null);
+  const [previewInverse, setPreviewInverse] = useState<number[][] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setStep('frame');
+      setError(null);
+      setSaving(false);
+      return;
+    }
+
+    const video = videoRef.current;
+    if (!video || !video.videoWidth || !video.videoHeight) {
+      setError('Video metadata not ready. Pause on the desired frame first.');
+      return;
+    }
+    video.pause();
+
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      setError('Unable to capture frame for calibration.');
+      return;
+    }
+
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const dataUrl = canvas.toDataURL('image/png');
+    setFrameImage(dataUrl);
+    setImageSize([canvas.width, canvas.height]);
+    setFrameTime(video.currentTime);
+    setCornerPoints([]);
+    setNetPoints([]);
+    setPreviewMatrix(null);
+    setPreviewInverse(null);
+    setStep('frame');
+    setError(null);
+  }, [open, videoRef]);
+
+  useEffect(() => {
+    if (step === 'confirm' && cornerPoints.length === 4) {
+      const matrix = computeHomography(cornerPoints, COURT_TEMPLATE_POINTS);
+      const inverse = invert3x3(matrix);
+      setPreviewMatrix(matrix);
+      setPreviewInverse(inverse);
+    } else {
+      setPreviewMatrix(null);
+      setPreviewInverse(null);
+    }
+  }, [step, cornerPoints]);
+
+  const handleStageClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!imageSize) return;
+      const img = imageRef.current;
+      if (!img) return;
+      const rect = img.getBoundingClientRect();
+      if (!rect.width || !rect.height) return;
+
+      const x = ((event.clientX - rect.left) / rect.width) * imageSize[0];
+      const y = ((event.clientY - rect.top) / rect.height) * imageSize[1];
+
+      if (x < 0 || y < 0 || x > imageSize[0] || y > imageSize[1]) return;
+
+      if (step === 'court' && cornerPoints.length < 4) {
+        setCornerPoints((prev) => [...prev, { x, y }]);
+      } else if (step === 'net' && netPoints.length < 2) {
+        setNetPoints((prev) => [...prev, { x, y }]);
+      }
+    },
+    [cornerPoints.length, imageSize, netPoints.length, step],
+  );
+
+  const resetToFrame = useCallback(() => {
+    setCornerPoints([]);
+    setNetPoints([]);
+    setStep('frame');
+    setPreviewMatrix(null);
+    setPreviewInverse(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!uploadId) {
+      setError('Upload ID required to save calibration.');
+      return;
+    }
+    if (!imageSize || cornerPoints.length !== 4 || netPoints.length !== 2) {
+      setError('Calibration incomplete.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch(`${apiBase}/calibration/${uploadId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          frame_t: frameTime,
+          image_size: imageSize,
+          image_points: cornerPoints.map(({ x, y }) => [x, y]),
+          court_template: 'indoor_fivb_18x9',
+          net_points: netPoints.map(({ x, y }) => [x, y]),
+        }),
+      });
+      if (!response.ok) {
+        const detail = await response.text();
+        throw new Error(detail || 'Unable to save calibration');
+      }
+      const payload = (await response.json()) as CalibrationData;
+      onSaved(payload);
+      onClose();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }, [apiBase, cornerPoints, frameTime, imageSize, netPoints, onClose, onSaved, uploadId]);
+
+  if (!open) return null;
+
+  const canAdvanceCourt = cornerPoints.length === 4;
+  const canAdvanceNet = netPoints.length === 2;
+
+  const renderMarkers = useMemo(() => {
+    if (!imageSize) return null;
+    const markers: React.ReactNode[] = [];
+    if (cornerPoints.length) {
+      markers.push(
+        <polyline
+          key="court"
+          points={cornerPoints
+            .map((point) => `${point.x},${point.y}`)
+            .concat(cornerPoints.length === 4 ? `${cornerPoints[0].x},${cornerPoints[0].y}` : [])
+            .join(' ')}
+          fill="none"
+          stroke="rgba(56,189,248,0.8)"
+          strokeWidth={2}
+        />,
+      );
+      cornerPoints.forEach((point, index) => {
+        markers.push(
+          <g key={`corner-${index}`}>
+            <circle cx={point.x} cy={point.y} r={6} fill="rgba(59,130,246,0.7)" />
+            <text x={point.x + 8} y={point.y - 8} fill="white" fontSize={12}>
+              {index + 1}
+            </text>
+          </g>,
+        );
+      });
+    }
+    if (netPoints.length) {
+      if (netPoints.length === 2) {
+        markers.push(
+          <line
+            key="net-line"
+            x1={netPoints[0].x}
+            y1={netPoints[0].y}
+            x2={netPoints[1].x}
+            y2={netPoints[1].y}
+            stroke="rgba(250,204,21,0.8)"
+            strokeWidth={3}
+          />,
+        );
+      }
+      netPoints.forEach((point, index) => {
+        markers.push(
+          <g key={`net-${index}`}>
+            <circle cx={point.x} cy={point.y} r={6} fill="rgba(250,204,21,0.9)" />
+            <text x={point.x + 8} y={point.y - 8} fill="white" fontSize={12}>
+              N{index + 1}
+            </text>
+          </g>,
+        );
+      });
+    }
+    return (
+      <svg
+        viewBox={`0 0 ${imageSize[0]} ${imageSize[1]}`}
+        className="pointer-events-none absolute inset-0 h-full w-full"
+      >
+        {markers}
+      </svg>
+    );
+  }, [cornerPoints, imageSize, netPoints]);
+
+  const renderConfirmOverlay = useMemo(() => {
+    if (!imageSize || !previewInverse) return null;
+    const segments: React.ReactNode[] = [];
+    COURT_LINES.forEach(([[ux0, uy0], [ux1, uy1]], index) => {
+      const start = applyMatrix(previewInverse, ux0, uy0);
+      const end = applyMatrix(previewInverse, ux1, uy1);
+      if (!start || !end) return;
+      segments.push(
+        <line
+          key={`grid-${index}`}
+          x1={start[0]}
+          y1={start[1]}
+          x2={end[0]}
+          y2={end[1]}
+          stroke="rgba(148,163,184,0.6)"
+          strokeWidth={1.5}
+        />,
+      );
+    });
+    if (netPoints.length === 2) {
+      segments.push(
+        <line
+          key="net-confirm"
+          x1={netPoints[0].x}
+          y1={netPoints[0].y}
+          x2={netPoints[1].x}
+          y2={netPoints[1].y}
+          stroke="rgba(56,189,248,0.8)"
+          strokeWidth={3}
+        />,
+      );
+    }
+    return (
+      <svg
+        viewBox={`0 0 ${imageSize[0]} ${imageSize[1]}`}
+        className="pointer-events-none absolute inset-0 h-full w-full"
+      >
+        {segments}
+      </svg>
+    );
+  }, [imageSize, netPoints, previewInverse]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-6">
+      <div className="w-full max-w-4xl rounded-xl border border-slate-700 bg-slate-900 shadow-xl">
+        <div className="flex items-center justify-between border-b border-slate-800 px-6 py-4">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Court Calibration</h2>
+            <p className="text-xs text-slate-400">Align the overlay grid and net with the captured frame.</p>
+          </div>
+          <button
+            type="button"
+            className="rounded-md border border-slate-700 px-3 py-1 text-xs text-slate-300 hover:border-slate-500"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+        <div className="px-6 py-6">
+          <div className="flex items-center gap-3 text-xs uppercase tracking-wide text-slate-500">
+            <StepPill active={step === 'frame'}>Frame</StepPill>
+            <StepPill active={step === 'court'}>Corners</StepPill>
+            <StepPill active={step === 'net'}>Net</StepPill>
+            <StepPill active={step === 'confirm'}>Confirm</StepPill>
+          </div>
+          <div
+            ref={stageRef}
+            onClick={handleStageClick}
+            className="relative mx-auto mt-4 flex min-h-[360px] w-full max-w-3xl items-center justify-center overflow-hidden rounded-lg border border-slate-700 bg-slate-950"
+          >
+            {frameImage ? (
+              <img ref={imageRef} src={frameImage} alt="Calibration frame" className="max-h-[400px] w-full object-contain" />
+            ) : (
+              <div className="py-32 text-center text-sm text-slate-400">Capture a frame from the video to begin.</div>
+            )}
+            {renderMarkers}
+            {step === 'confirm' && renderConfirmOverlay}
+          </div>
+          <div className="mt-6 space-y-3 text-sm text-slate-300">
+            {step === 'frame' && (
+              <p>Use the paused frame currently visible in the player for calibration. Click “Mark corners” to begin.</p>
+            )}
+            {step === 'court' && (
+              <div>
+                <p>Click the four court corners in order: left-near, right-near, right-far, left-far.</p>
+                <ul className="mt-2 grid grid-cols-2 gap-2 text-xs text-slate-400">
+                  {CORNER_LABELS.map((label, index) => (
+                    <li
+                      key={label}
+                      className={`rounded border px-2 py-1 ${
+                        cornerPoints[index]
+                          ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-100'
+                          : 'border-slate-700 text-slate-500'
+                      }`}
+                    >
+                      {index + 1}. {label}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {step === 'net' && (
+              <p>Click two points along the top of the net tape to define the net line.</p>
+            )}
+            {step === 'confirm' && (
+              <p>Review the overlay alignment below. If everything looks correct, save the calibration to enable court overlays.</p>
+            )}
+          </div>
+          {error && (
+            <div className="mt-4 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">{error}</div>
+          )}
+          <div className="mt-6 flex justify-between">
+            <button
+              type="button"
+              className="rounded-md border border-slate-700 px-3 py-2 text-xs uppercase tracking-wide text-slate-300 hover:border-slate-500"
+              onClick={resetToFrame}
+            >
+              Reset
+            </button>
+            <div className="flex items-center gap-2">
+              {step !== 'frame' && (
+                <button
+                  type="button"
+                  className="rounded-md border border-slate-700 px-3 py-2 text-xs uppercase tracking-wide text-slate-300 hover:border-slate-500"
+                  onClick={() => {
+                    if (step === 'court') {
+                      setCornerPoints((prev) => prev.slice(0, -1));
+                    } else if (step === 'net') {
+                      setNetPoints((prev) => prev.slice(0, -1));
+                    }
+                    setStep(step === 'confirm' ? 'net' : step === 'net' ? 'court' : 'frame');
+                  }}
+                >
+                  Back
+                </button>
+              )}
+              {step === 'frame' && (
+                <button
+                  type="button"
+                  className="rounded-md bg-brand px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white"
+                  onClick={() => setStep('court')}
+                >
+                  Mark corners
+                </button>
+              )}
+              {step === 'court' && (
+                <button
+                  type="button"
+                  disabled={!canAdvanceCourt}
+                  className={`rounded-md px-4 py-2 text-xs font-semibold uppercase tracking-wide ${
+                    canAdvanceCourt ? 'bg-brand text-white' : 'bg-slate-800 text-slate-500'
+                  }`}
+                  onClick={() => setStep('net')}
+                >
+                  Mark net
+                </button>
+              )}
+              {step === 'net' && (
+                <button
+                  type="button"
+                  disabled={!canAdvanceNet}
+                  className={`rounded-md px-4 py-2 text-xs font-semibold uppercase tracking-wide ${
+                    canAdvanceNet ? 'bg-brand text-white' : 'bg-slate-800 text-slate-500'
+                  }`}
+                  onClick={() => setStep('confirm')}
+                >
+                  Review
+                </button>
+              )}
+              {step === 'confirm' && (
+                <button
+                  type="button"
+                  className="rounded-md bg-emerald-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-950 hover:bg-emerald-400"
+                  onClick={handleSave}
+                  disabled={saving}
+                >
+                  {saving ? 'Saving…' : 'Save calibration'}
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="mt-4 text-right text-[11px] text-slate-500">
+            Frame time: {frameTime.toFixed(2)}s
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const StepPill: React.FC<{ active: boolean; children: React.ReactNode }> = ({ active, children }) => (
+  <span
+    className={`rounded-full border px-3 py-1 text-[10px] font-semibold ${
+      active
+        ? 'border-brand/40 bg-brand/20 text-brand-100'
+        : 'border-slate-700 bg-slate-800 text-slate-500'
+    }`}
+  >
+    {children}
+  </span>
+);
+
+function computeHomography(imagePoints: Point2D[], courtPoints: [number, number][]): number[][] {
+  if (imagePoints.length !== courtPoints.length || imagePoints.length !== 4) {
+    throw new Error('Homography requires four point correspondences.');
+  }
+  const a: number[][] = [];
+  const b: number[] = [];
+  for (let i = 0; i < 4; i += 1) {
+    const { x, y } = imagePoints[i];
+    const [u, v] = courtPoints[i];
+    a.push([x, y, 1, 0, 0, 0, -u * x, -u * y]);
+    b.push(u);
+    a.push([0, 0, 0, x, y, 1, -v * x, -v * y]);
+    b.push(v);
+  }
+  const solution = solveLinearSystem(a, b);
+  const [h0, h1, h2, h3, h4, h5, h6, h7] = solution;
+  return [
+    [h0, h1, h2],
+    [h3, h4, h5],
+    [h6, h7, 1],
+  ];
+}
+
+function solveLinearSystem(a: number[][], b: number[]): number[] {
+  const n = a.length;
+  const m = a[0].length;
+  const augmented = a.map((row, index) => [...row, b[index]]);
+  for (let col = 0; col < m; col += 1) {
+    let pivot = col;
+    for (let row = col + 1; row < n; row += 1) {
+      if (Math.abs(augmented[row][col]) > Math.abs(augmented[pivot][col])) {
+        pivot = row;
+      }
+    }
+    if (Math.abs(augmented[pivot][col]) < 1e-9) {
+      continue;
+    }
+    if (pivot !== col) {
+      const temp = augmented[col];
+      augmented[col] = augmented[pivot];
+      augmented[pivot] = temp;
+    }
+    const pivotValue = augmented[col][col];
+    for (let j = col; j <= m; j += 1) {
+      augmented[col][j] /= pivotValue;
+    }
+    for (let row = 0; row < n; row += 1) {
+      if (row === col) continue;
+      const factor = augmented[row][col];
+      for (let j = col; j <= m; j += 1) {
+        augmented[row][j] -= factor * augmented[col][j];
+      }
+    }
+  }
+  return augmented.slice(0, m).map((row) => row[m]);
+}
+
+function invert3x3(matrix: number[][] | null): number[][] | null {
+  if (!matrix) return null;
+  const size = 3;
+  const augmented = matrix.map((row, index) => {
+    const identity = Array(size)
+      .fill(0)
+      .map((_, idx) => (idx === index ? 1 : 0));
+    return [...row, ...identity];
+  });
+  for (let col = 0; col < size; col += 1) {
+    let pivot = col;
+    for (let row = col + 1; row < size; row += 1) {
+      if (Math.abs(augmented[row][col]) > Math.abs(augmented[pivot][col])) {
+        pivot = row;
+      }
+    }
+    if (Math.abs(augmented[pivot][col]) < 1e-9) {
+      return null;
+    }
+    if (pivot !== col) {
+      const temp = augmented[col];
+      augmented[col] = augmented[pivot];
+      augmented[pivot] = temp;
+    }
+    const pivotValue = augmented[col][col];
+    for (let j = col; j < size * 2; j += 1) {
+      augmented[col][j] /= pivotValue;
+    }
+    for (let row = 0; row < size; row += 1) {
+      if (row === col) continue;
+      const factor = augmented[row][col];
+      for (let j = col; j < size * 2; j += 1) {
+        augmented[row][j] -= factor * augmented[col][j];
+      }
+    }
+  }
+  return augmented.map((row) => row.slice(size));
+}
+
+function applyMatrix(matrix: number[][], x: number, y: number): [number, number] | null {
+  if (!matrix || matrix.length !== 3) return null;
+  const denom = matrix[2][0] * x + matrix[2][1] * y + matrix[2][2];
+  if (Math.abs(denom) < 1e-6) return null;
+  const px = (matrix[0][0] * x + matrix[0][1] * y + matrix[0][2]) / denom;
+  const py = (matrix[1][0] * x + matrix[1][1] * y + matrix[1][2]) / denom;
+  return [px, py];
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -10,7 +10,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "skipLibCheck": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary
- add calibration and annotation routers plus homography helpers to persist overlays server-side
- implement a React overlay canvas with tool drawer, calibration grid rendering, and persisted annotation saving
- introduce a calibration wizard and timeline thumbnail previews, with Zustand-based tool state and updated dependencies

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d221f5b85083259feb2b0a40dca41e