### PR TITLE
Ensure the web container installs dependencies at runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: docker/web.Dockerfile
-    command: npm run dev -- --host 0.0.0.0 --port 5173
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
     environment:
       - VITE_API_URL=http://localhost:8000
       - VITE_ENABLE_TRAINER=${ENABLE_TRAINER:-true}


### PR DESCRIPTION
## Summary
- run `npm install` before starting the Vite dev server so new frontend dependencies are available in the mounted node_modules volume

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d22922f4d88325a49f0c86bf4b2d4b