### PR TITLE
Replace zustand overlay store with internal implementation

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,8 +11,7 @@
         "@headlessui/react": "^1.7.17",
         "lucide-react": "^0.304.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "zustand": "^4.5.2"
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.1.4",
@@ -1500,14 +1499,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2609,7 +2608,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -6557,15 +6556,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7073,34 +7063,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
-      "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=12.7.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "immer": ">=9.0.6",
-        "react": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -14,8 +14,7 @@
     "@headlessui/react": "^1.7.17",
     "lucide-react": "^0.304.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "zustand": "^4.5.2"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.4",

--- a/web/src/hooks/useOverlayTool.ts
+++ b/web/src/hooks/useOverlayTool.ts
@@ -1,5 +1,4 @@
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { useCallback, useEffect, useState } from 'react';
 
 export type OverlayTool = 'select' | 'box' | 'lasso';
 
@@ -8,14 +7,66 @@ interface OverlayToolState {
   setTool: (tool: OverlayTool) => void;
 }
 
-export const useOverlayTool = create<OverlayToolState>()(
-  persist(
-    (set) => ({
-      tool: 'select',
-      setTool: (tool) => set({ tool }),
-    }),
-    {
-      name: 'overlay-tool',
-    },
-  ),
-);
+const STORAGE_KEY = 'overlay-tool';
+
+const isOverlayTool = (value: unknown): value is OverlayTool =>
+  value === 'select' || value === 'box' || value === 'lasso';
+
+const getStoredTool = (): OverlayTool => {
+  if (typeof window === 'undefined') {
+    return 'select';
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return isOverlayTool(stored) ? stored : 'select';
+};
+
+let currentTool: OverlayTool = getStoredTool();
+const listeners = new Set<(tool: OverlayTool) => void>();
+
+const setCurrentTool = (tool: OverlayTool) => {
+  currentTool = tool;
+
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, tool);
+  }
+
+  listeners.forEach((listener) => listener(tool));
+};
+
+export const useOverlayTool = (): OverlayToolState => {
+  const [tool, setToolState] = useState<OverlayTool>(currentTool);
+
+  useEffect(() => {
+    const listener = (nextTool: OverlayTool) => setToolState(nextTool);
+    listeners.add(listener);
+
+    // Ensure the subscribing component sees the latest value.
+    listener(currentTool);
+
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY && isOverlayTool(event.newValue)) {
+        setCurrentTool(event.newValue);
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const setTool = useCallback((nextTool: OverlayTool) => {
+    setCurrentTool(nextTool);
+  }, []);
+
+  return { tool, setTool };
+};


### PR DESCRIPTION
## Summary
- replace the zustand-based overlay tool store with an internal React hook that persists to localStorage, removing the dependency on zustand
- drop zustand from the web package manifest to keep the dependency tree clean

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d22b6770988325b4a5ebfdaf2c865f