### PR TITLE
Configure API proxy target override

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ docker/         # Runtime Dockerfiles
 ## Getting started
 
 1. Install the dependencies for both the API and the web client (see commands below).
-2. Copy the sample environment file and adjust provider URLs as needed.
+2. Copy the sample environment file and adjust provider URLs as needed. If your frontend needs to proxy to an API host that
+   differs from the browser-facing `VITE_API_URL`, set `VITE_API_PROXY_TARGET` to that backend host (for example, the Docker
+   service name when using `docker-compose`).
 3. Run `docker-compose up --build` to start the stack (API on port 8000, web on port 5173).
 
 The backend exposes mocked routes for analysis, events, stats, exports, trainer proposals, ingest progress, ScreenSnap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
     environment:
       - VITE_API_URL=http://localhost:8000
+      - VITE_API_PROXY_TARGET=http://api:8000
       - VITE_ENABLE_TRAINER=${ENABLE_TRAINER:-true}
       - VITE_ENABLE_SCREEN_SNAP=${ENABLE_SCREEN_SNAP:-true}
       - VITE_ENABLE_INSIGHTS=${ENABLE_INSIGHTS:-true}

--- a/web/.env.sample
+++ b/web/.env.sample
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:8000
+VITE_API_PROXY_TARGET=

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -9,7 +9,8 @@ export default defineConfig(({ mode }) => {
       port: 5173,
       proxy: {
         '/api': {
-          target: env.VITE_API_URL || 'http://localhost:8000',
+          target:
+            env.VITE_API_PROXY_TARGET || env.VITE_API_URL || 'http://localhost:8000',
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/api/, ''),
         },


### PR DESCRIPTION
## Summary
- allow the Vite dev proxy to prefer the new `VITE_API_PROXY_TARGET` before falling back to `VITE_API_URL`
- configure the web service in docker-compose to point the proxy to the API container by default
- document the new environment variable and include it in the web client sample env file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ec6404f083259012e589dc4460c1