### PR TITLE
Allow configuring frontend CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ docker/         # Runtime Dockerfiles
    service name when using `docker-compose`).
 3. Run `docker-compose up --build` to start the stack (API on port 8000, web on port 5173).
 
+If you access the frontend from a host other than `http://localhost:5173` (for example, a Docker network IP, Codespaces URL, or
+ngrok tunnel), set the backend `ALLOWED_FRONTEND_ORIGINS` environment variable to a comma-separated list of origins so the API
+will accept requests from those addresses. The default value already includes the local Vite dev server.
+
 The backend exposes mocked routes for analysis, events, stats, exports, trainer proposals, ingest progress, ScreenSnap
 annotations, and LLM insights. The frontend renders the multi-panel console experience with module guards, error boundaries,
 and feature flags.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Dict
+from typing import Dict, List
 
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -17,6 +18,27 @@ class Settings(BaseSettings):
     enable_screen_snap: bool = True
     enable_insights: bool = True
     enable_exports: bool = True
+    allowed_frontend_origins: List[str] = Field(
+        default_factory=lambda: ["http://localhost:5173"]
+    )
+
+    @field_validator("allowed_frontend_origins", mode="before")
+    @classmethod
+    def _parse_allowed_frontend_origins(cls, value: object) -> List[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return []
+            return [origin.strip() for origin in stripped.split(",") if origin.strip()]
+        if isinstance(value, (list, tuple)):
+            return [str(origin).strip() for origin in value if str(origin).strip()]
+        if isinstance(value, (set, frozenset)):
+            return [str(origin).strip() for origin in value if str(origin).strip()]
+        raise TypeError(
+            "allowed_frontend_origins must be provided as a list, tuple, set, or comma-separated string"
+        )
 
     model_config = SettingsConfigDict(env_prefix="", case_sensitive=False)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -58,9 +58,11 @@ for logger_name in ("", "uvicorn", "uvicorn.error", "uvicorn.access", "uvicorn.a
 app.state.log_buffer = log_buffer
 app.state.log_handler = log_handler
 
+cors_allow_origins = settings.allowed_frontend_origins or ["http://localhost:5173"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=cors_allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ENABLE_INSIGHTS=${ENABLE_INSIGHTS:-true}
       - ENABLE_INGEST=${ENABLE_INGEST:-true}
       - ENABLE_EXPORTS=${ENABLE_EXPORTS:-true}
+      - ALLOWED_FRONTEND_ORIGINS=${ALLOWED_FRONTEND_ORIGINS:-http://localhost:5173}
     ports:
       - '8000:8000'
   web:


### PR DESCRIPTION
## Summary
- add a configurable list of allowed frontend origins to the FastAPI settings
- wire the CORSMiddleware to use the configured origins with a localhost fallback
- document and expose the new ALLOWED_FRONTEND_ORIGINS variable in docker-compose for local development

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2ecfcaf6083258b8024fda3acac6d